### PR TITLE
hardfloat misspelled

### DIFF
--- a/documentation/2-后端流水线.md
+++ b/documentation/2-后端流水线.md
@@ -7,17 +7,18 @@
 ![backend](./images/backend/backend.png)
 
 在雁栖湖版本中，上述4个Block分别采用如下配置：
+
 - CtrlBlock
-    - 译码/重命名/分派宽度=6
-    - 发射前读寄存器堆
+  - 译码/重命名/分派宽度=6
+  - 发射前读寄存器堆
 - IntBlock
-    - 160项物理寄存器
-    - 4 * ALU + 2 * MUL/DIV + 1 * CSR/JMP
+  - 160项物理寄存器
+  - 4 * ALU + 2 * MUL/DIV + 1 * CSR/JMP
 - FloatBlock
-    - 160项物理寄存器堆
-    - 4 * FMAC + 2 * FMISC
+  - 160项物理寄存器堆
+  - 4 * FMAC + 2 * FMISC
 - MemBlock
-    - 2 * LOAD + 2 * STORE
+  - 2 * LOAD + 2 * STORE
 
 ## CtrlBlock
 
@@ -51,8 +52,8 @@
 
 ![float-block](./images/backend/float-block.png)
 
-- FPR 内部采用 recode [1] 格式存储浮点数(65-bit)
-- 浮点功能单元基于Hardflaot [1]，对其原版 FMAC 和 FDIVSQRT 进行了优化
+- FPR 内部采用 recode [1][1] 格式存储浮点数(65-bit)
+- 浮点功能单元基于HardFloat [1][1]，对其原版 FMAC 和 FDIVSQRT 进行了优化
 - FMAC 部件分为5拍，FDIVSQRT 采用SRT-4实现
 
 ### recode 格式
@@ -63,4 +64,3 @@
 - recode 格式需要在 FloatBlock 与外部进行数据交互时对浮点数做转换，带来了额外的延迟
 
 [1]: https://github.com/ucb-bar/berkeley-hardfloat.git
-


### PR DESCRIPTION
The word 'HardFloat' in "2-后端流水线.md" is misspelled.