### PR TITLE
doc, tools: fix typos and links, add zh version

### DIFF
--- a/docs/tools/troubleshoot-zh.md
+++ b/docs/tools/troubleshoot-zh.md
@@ -1,0 +1,17 @@
+Troubleshooting 指南
+================
+
+This chapter has [English version](./troubleshoot.md).
+
+* 编译和仿真香山代码需要耗费大量内存，请确保设备具有足够的内存。对于 MinimalConfig 选项，我们推荐内存至少为 32GB；对于完整的香山核，推荐内存至少为 64GB。（参见：[https://github.com/OpenXiangShan/XiangShan/issues/995](https://github.com/OpenXiangShan/XiangShan/issues/995)）
+    * 改变 swap 区的大小可能有所帮助。（参见：[https://github.com/OpenXiangShan/XiangShan/issues/852](https://github.com/OpenXiangShan/XiangShan/issues/852)）
+* 香山需要 Java 11 或更高的版本，请确认 Java 的版本。我们已经了解到香山在 Java 8 环境下无法正常工作。
+    * 我们推荐使用 graalvm 代替 openjdk 以降低内存消耗，同时提高编译速度。（参见：[https://github.com/OpenXiangShan/XiangShan/issues/997](https://github.com/OpenXiangShan/XiangShan/issues/997)）
+* 在 `XiangShan/build.sc`中的 `-Xmx64G` 可能影响香山的编译过程，请检查 JVM 的参数。（参见：[https://github.com/OpenXiangShan/XiangShan/issues/906](https://github.com/OpenXiangShan/XiangShan/issues/906)）
+* 基于仿真 snapshot 的 fork-wait 需要 Verilator v4.204 版本，请确认 Verilator 的版本。我们不建议使用通过 `apt get` 方式安装 Verilator，这样得到的版本很低。手动安装 Verilator 可以参考 [https://github.com/OpenXiangShan/xs-env/blob/master/install-verilator.sh](https://github.com/OpenXiangShan/xs-env/blob/master/install-verilator.sh) (v4.204) 或官方教程 [https://verilator.org/guide/latest/install.html](https://verilator.org/guide/latest/install.html)。
+* 请检查子模块是否已经正确初始化，如果遇到来自于香山本身或者其子模块的奇怪的语法错误，有可能是因为子模块并没有被正确初始化。可以尝试通过在 `Xiangshan` 目录下运行 `make init` 进行对子模块重新进行下载。
+    * 香山需要从 GitHub 中克隆子模块，请确认你的设备可以连上 GitHub，或者可以手动将这些子模块下载下来。
+* 编译或仿真默认配置的完整香山核需要花费大量的时间和内存空间，可以首先尝试最小配置的香山 (`make emu CONFIG=MinimalConfig`)，从而确认香山的环境是否已经配置正确。（参见：[https://github.com/OpenXiangShan/XiangShan/issues/852](https://github.com/OpenXiangShan/XiangShan/issues/852)）
+* 生成行为仿真用 verilog 代码和可综合 verilog 代码的命令是不同的。通过 `make verilog` 命令可以生成可综合的 verilog 代码；而 `make emu` 用于行为仿真。（参见：[https://github.com/OpenXiangShan/XiangShan/issues/933](https://github.com/OpenXiangShan/XiangShan/issues/933)）
+
+另外，[https://github.com/OpenXiangShan/xs-env](https://github.com/OpenXiangShan/xs-env) 提供了搭建香山开发环境的一些辅助工具，包括用于安装香山依赖的脚本，以及相关的文档。

--- a/docs/tools/troubleshoot.md
+++ b/docs/tools/troubleshoot.md
@@ -1,21 +1,21 @@
 Compiling Troubleshooting Guide
 ================
 
-* Make sure your device have enough memory. Xiangshan project is quite memory intensive. We recommend 32GB memory for MinimalConfig and 64GB memory for full XiangShan. (https://github.com/OpenXiangShan/XiangShan/issues/995)
-    * Change swap size may help. (https://github.com/OpenXiangShan/XiangShan/issues/852)
+* Make sure your device have enough memory. Xiangshan project is quite memory intensive. We recommend 32GB memory for MinimalConfig and 64GB memory for full XiangShan. ([https://github.com/OpenXiangShan/XiangShan/issues/995](https://github.com/OpenXiangShan/XiangShan/issues/995))
+    * Change swap size may help. ([https://github.com/OpenXiangShan/XiangShan/issues/852](https://github.com/OpenXiangShan/XiangShan/issues/852))
 
-* Check Java version. XiangShan requires Java 11 or higher version. We have already know that XiangShan dose not work on Java 8.
-    * By the way, we recommend using graalvm to reduce memory cost and speedup compiling as well. (https://github.com/OpenXiangShan/XiangShan/issues/997)
+* Check Java version. XiangShan requires Java 11 or higher version. We have already know that XiangShan does not work on Java 8.
+    * By the way, we recommend using graalvm to reduce memory cost and speedup compiling as well. ([https://github.com/OpenXiangShan/XiangShan/issues/997](https://github.com/OpenXiangShan/XiangShan/issues/997))
 
-* Check JVM arguments. `-Xmx64G` in `XiangShan/build.sc` may influence XiangShan compiling. (Chinese: https://github.com/OpenXiangShan/XiangShan/issues/906)
+* Check JVM arguments. `-Xmx64G` in `XiangShan/build.sc` may influence XiangShan compiling. (Chinese: [https://github.com/OpenXiangShan/XiangShan/issues/906](https://github.com/OpenXiangShan/XiangShan/issues/906))
 
-* Check Verilator version. Fork-wait based simulation snapshot requires Verilator v4.204. We suggest you use that version instead of `apt get` version (which is much lower). To setup Verilator manually, see https://github.com/OpenXiangShan/xs-env/blob/master/install-verilator.sh (Verilator v4.204) or https://verilator.org/guide/latest/install.html (Offical Verilator install instructions).
+* Check Verilator version. Fork-wait based simulation snapshot requires Verilator v4.204. We suggest you use that version instead of `apt get` version (which is much lower). To setup Verilator manually, see [https://github.com/OpenXiangShan/xs-env/blob/master/install-verilator.sh](https://github.com/OpenXiangShan/xs-env/blob/master/install-verilator.sh) (Verilator v4.204) or [https://verilator.org/guide/latest/install.html](https://verilator.org/guide/latest/install.html) (Offical Verilator install instructions).
 
 * Check if submodules are initialized correctly. If you meet strange syntax errors from submodules or XiangShan itself, it may because of that submodules are not initialized correctly. Run `make init` in `XiangShan` to re-init submodules may help.
     * Make sure your device have access to GitHub. XiangShan needs to clone submodules from GitHub. Or you may download these submodules manually.
 
-* Try Minimal XiangShan first. XiangShan's default config will take quite long time and huge memory space to build. We suggest you try Minimal XiangShan (`make emu CONFIG=MinimalConfig`) first to make sure the environment is set up correctly. (https://github.com/OpenXiangShan/XiangShan/issues/852)
+* Try Minimal XiangShan first. XiangShan's default config will take quite long time and huge memory space to build. We suggest you try Minimal XiangShan (`make emu CONFIG=MinimalConfig`) first to make sure the environment is set up correctly. ([https://github.com/OpenXiangShan/XiangShan/issues/852](https://github.com/OpenXiangShan/XiangShan/issues/852))
 
-* Commands for generating behavior simulation verilog and synthesizable synthesizable are different. Run `make verilog` to generate synthesizable verilog. Run `make emu` for behavior simulation (https://github.com/OpenXiangShan/XiangShan/issues/933)
+* Commands for generating behavior simulation verilog and synthesizable verilog are different. Run `make verilog` to generate synthesizable verilog. Run `make emu` for behavior simulation ([https://github.com/OpenXiangShan/XiangShan/issues/933](https://github.com/OpenXiangShan/XiangShan/issues/933))
 
-By the way, https://github.com/OpenXiangShan/xs-env provides scripts for installing XiangShan dependencies and a detailed document (Chinese only, En WIP) about how to set up XiangShan develop environment.
+By the way, [https://github.com/OpenXiangShan/xs-env](https://github.com/OpenXiangShan/xs-env) provides scripts for installing XiangShan dependencies and a detailed document (Chinese only, En WIP) about how to set up XiangShan develop environment.

--- a/docs/tools/xsenv.md
+++ b/docs/tools/xsenv.md
@@ -3,15 +3,13 @@ XiangShan 前端开发环境
 
 在这一章中，我们将介绍如何编译和仿真香山代码、如何生成可运行的 Workload，并介绍一些开发中用到的辅助工具。
 
-如果遇到问题，可以参考 [Troubleshooting](./troubleshoot.md) 以及 [https://github.com/OpenXiangShan/XiangShan/issues](https://github.com/OpenXiangShan/XiangShan/issues) 中的问题及解答。
+如果遇到问题，可以参考 [Troubleshooting](./troubleshoot-zh.md) 以及 [https://github.com/OpenXiangShan/XiangShan/issues](https://github.com/OpenXiangShan/XiangShan/issues) 中的问题及解答。
 
 This chapter has [English version](./xsenv-en.md).
 
 ## TLDR
 
 使用以下脚本来布署香山开发环境，**部署脚本只需运行一次.**：
-
-This script will setup XiangShan develop environment automatically. Note that `./setup-tools.sh` and `setup.sh` only need to be run **ONCE**.
 
 ```sh
 git clone https://github.com/OpenXiangShan/xs-env
@@ -21,8 +19,6 @@ source setup.sh # prepare tools, test develop env using a small project
 ```
 
 **环境部署成功后，每次要使用开发环境时，只需使用以下命令配置环境变量**：
-
-After XiangShan Develop Environment setup, use the following script **every time** before using XiangShan Develop Environment.
 
 ```sh
 cd xs-env
@@ -34,7 +30,7 @@ source ./env.sh # setup XiangShan environment variables
 请准备一台**性能较强**的服务器，以下为服务器的一些配置要求：
 
 - 操作系统：Ubuntu 20.04 LTS （其他版本未测试，不建议使用）
-CPU：不限，性能将决定编译与生成的速度
+- CPU：不限，性能将决定编译与生成的速度
 - 内存：**最低 32G，推荐 64G 及以上**
 - 磁盘空间：20G 及以上
 - 网络：请自行配置顺畅的网络环境
@@ -145,7 +141,7 @@ make riscv64-xs_defconfig
 make -j
 ```
 > 提示：新旧版本的 NEMU 使用略有区别。要从旧版本的 NEMU 迁移到新版本的 NEMU，可以参考以下文档：
-> [htps://github.com/OpenXiangShan/NEMU/wiki/%E6%96%B0NEMU%E4%B8%B4%E6%97%B6%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97](https://github.com/OpenXiangShan/NEMU/wiki/%E6%96%B0NEMU%E4%B8%B4%E6%97%B6%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97)
+> [新版本 NEMU 使用指南](https://github.com/OpenXiangShan/NEMU/wiki/%E6%96%B0NEMU%E4%B8%B4%E6%97%B6%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97)
 
 接下来运行 `./build/riscv64-nemu-interpreter -b MY_WORKLOAD.bin` 其中将 `MY_WORKLOAD.bin` 替换为想要运行镜像的路径，例如上一节中生成的 coremark，即可让 NEMU 模拟器运行指定的程序了。例如：
 
@@ -160,7 +156,7 @@ make -j
 ```bash
 make emu CONFIG=MinimalConfig EMU_TRACE=1 -j32
 ```
-将会生成一个最小配置的香山的仿真程序，这一步时间会比较久，需要耐心等待。生成结束后，可以在 `./build/` 目录下看到一个名为 `emu` 的仿真程序。其中，`CONFIG=MinimalConfig`指定了香山核使用的配置（参见：[https://github.com/OpenXiangShan/XiangShan-doc/blob/main/documentation/0-%E5%8F%82%E6%95%B0%E7%B3%BB%E7%BB%9F.md](https://github.com/OpenXiangShan/XiangShan-doc/blob/main/documentation/0-%E5%8F%82%E6%95%B0%E7%B3%BB%E7%BB%9F.md)），`EMU_TRACE=1`会为仿真程序添加波形输出功能，允许在仿真过程中启用波形输出。
+将会生成一个最小配置的香山的仿真程序，这一步时间会比较久，需要耐心等待。生成结束后，可以在 `./build/` 目录下看到一个名为 `emu` 的仿真程序。其中，`CONFIG=MinimalConfig`指定了香山核使用的配置（参见：[香山参数系统说明](https://xiangshan-doc.readthedocs.io/zh_CN/latest/misc/config/)），`EMU_TRACE=1`会为仿真程序添加波形输出功能，允许在仿真过程中启用波形输出。
 
 
 > 更多参数请参考`Makefile`脚本代码。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,6 @@ nav:
             - NEMU: tools/nemu.md
             - 制作 Debian 镜像: tools/debian.md
             # - 常用脚本: tools/scripts.md
-        - Troubleshooting: tools/troubleshoot.md
+        - Troubleshooting: tools/troubleshoot-zh.md
     - 编译工具链:
         - riscv-gnu-toolchain: compiler/gnu_toolchain.md


### PR DESCRIPTION
* troubleshoot-zh.md: translate English version to Chinese

* xsenv.md: fix invalid link, use zh Troubleshoot

* troubleshoot.md: fix typos, use hyperlinks

* mkdocs.yml: use zh Troubleshoot as default