### PR TITLE
compile-and-sim: add PGO

### DIFF
--- a/docs/tools/compile-and-sim.md
+++ b/docs/tools/compile-and-sim.md
@@ -29,6 +29,41 @@ Verilator会将Chisel生成的Verilog源码转换为数百/千个C++源文件，
 
 ## 加快emu仿真运行速度
 
-1.通过`EMU_THREADS`指定emu仿真时要使用的线程数，例如`make emu EMU_THREADS=8`。
+1. 通过`EMU_THREADS`指定emu仿真时要使用的线程数，例如`make emu EMU_THREADS=8`。
 
-2.使用`numactl`将emu运行时使用的核限制在一个node内，例如`numactl -m 0 -C 0-7 ./build/emu ...`
+2. 使用`numactl`将emu运行时使用的核限制在一个node内，例如`numactl -m 0 -C 0-7 ./build/emu ...`
+
+3. 对 Verilator 编译的 C++ 代码使用 Profile Guided Optimization (PGO)
+
+    我们提供了以下参数进行 PGO :
+
+    - `PGO_WORKLOAD`: 用于指定 PGO 的工作负载，例如 <code>PGO_WORKLOAD=\`realpath ready-to-run/coremark-2-iteration.bin\`</code>。
+    - `PGO_MAX_CYCLE`: 仿真器运行 PGO 的最大周期数，默认值为 `2000000` 。
+    - `PGO_EMU_ARGS`: 指定 PGO 运行时的参数，例如担心 CPU 存在 Bug 影响 PGO 执行可以指定 `PGO_EMU_ARGS='--no-diff'` 。
+    - `LLVM_PROFDATA`: 指定 llvm-profdata 版本，通常情况下传递 `LLVM_PROFDATA=llvm-profdata` 即可。 
+
+    使用举例：
+
+    ```bash
+    make emu EMU_THREADS=8 \
+             PGO_WORKLOAD=`realpath ready-to-run/coremark-2-iteration.bin` \
+             LLVM_PROFDATA=llvm-profdata \
+             -j `nproc`
+    ``` 
+
+    !!! warning
+        若在 Debian / Ubuntu 中安装了不同版本的 clang 与 llvm 时，需将 `LLVM_PROFDATA` 指定为对应版本。例如 Verilator 使用了 clang-18 ，则相应地需要指定 `LLVM_PROFDATA=llvm-profdata-18` 。使用 `GCC` 编译 Verilator 生成的 C 文件时请将该参数留空，否则将因为找不到 LLVM 生成的 Profile 文件而导致报错。
+
+    !!! info
+        对于已经完成编译的 emu ，开启 PGO 不需要 `make clean`，这会导致 Chisel 的重新编译以及 Verilator 重新生成 C 代码，仅需 <code>make -C ./difftest clean_obj DESIGN_DIR=\`pwd\`</code> ，再重新执行上述的 `make emu PGO...` 即可，在大多数机器上可在 15 分钟内完成。
+    
+    !!! info
+        部份编译器特性可能导致 O3 + PGO + Verilator 生成的 C 代码编译非常缓慢，已知 LLVM-18 存在，可以尝试指定 `OPT_FAST=-O1` 编译，通常性能损失不多，依然会比非 PGO 的 O3 快上不少。例如：
+        ```bash
+        make emu EMU_THREADS=8 OPT_FAST=-O1 \
+                 PGO_WORKLOAD=`realpath ready-to-run/coremark-2-iteration.bin` \
+                 LLVM_PROFDATA=llvm-profdata \
+                 -j `nproc`
+        ``` 
+
+    PGO 通常能让仿真速度在 L3 Cache 足够的情况下提升 2 倍左右，经过测试在使用香山`commit 9810c04`，在 AMD 7950X3D + LLVM-14 平台上 8 线程 Verilator 使用 CoreMark 训练 PGO，后续使用 numactl 绑定到具有 96M L3 Cache 的 CCX ，运行 CoreMark 测试可以达到约 9K Cycles/s 的仿真速度，而不使用 PGO 只有约 4K Cycles/s。


### PR DESCRIPTION
This PR shows how to use PGO to compile the verilator-generated C code.