### PR TITLE
doc, tools: Use `make clean-all` before change NEMU config

### DIFF
--- a/docs/tools/xsenv-en.md
+++ b/docs/tools/xsenv-en.md
@@ -137,7 +137,7 @@ NEMU is an instruction set emulator. We use NEMU as the implementation reference
 Before running the workload on the NEMU emulator, we need to make sure the virtual peripherals of NEMU uses the same address as Xiangshan. Go to the `/xs-env/NEMU` directory and run the following command:
 
 ```bash
-make clean
+make clean-all
 make riscv64-xs_defconfig
 ```
 
@@ -192,7 +192,7 @@ To run co-simulation, NEMU needs to be configured before co-simulation starts. N
 Run under `/xs-env/NEMU`:
 
 ```
-make clean
+make clean-all
 make riscv64-xs-ref_defconfig
 make -j
 ```

--- a/docs/tools/xsenv.md
+++ b/docs/tools/xsenv.md
@@ -153,7 +153,8 @@ coremark-riscv64-xs.txt  应用程序的反汇编
 
 在使用 NEMU 模拟器运行 workload 时，我们需要将模拟器的虚拟外设与香山的外设地址空间对齐。进入 `/xs-env/NEMU` 目录，运行以下命令：
 ```bash
-make clean
+make clean-all
+
 make riscv64-xs_defconfig
 ```
 随后，使用以下命令编译 NEMU 模拟器：
@@ -200,7 +201,8 @@ make emu -j32
 
 在 `/xs-env/NEMU`下运行：
 ```
-make clean
+make clean-all
+
 make riscv64-xs-ref_defconfig
 make -j
 ```


### PR DESCRIPTION
The NEMU was built as standalone binary w/o `-fPIC` in early section "Run workload using NEMU emulator". And in the following section "Run workload on Xiangshan core simulator", the NEMU was built as shared library, in which the `-fPIC` flag was requried.

But the default `make clean` target did not cleanup the build output file `resource/softfloat/build/softfloat.a`, which cause the linker report following error:

```
+ ccache g++ /home/xiangshan/xs-env/NEMU/build/riscv64-nemu-interpreter-so
/usr/bin/ld: resource/softfloat/build/softfloat.a(s_mulAddF64.o): warning: relocation against `softfloat_roundingMode' in read-only section `.text'
/usr/bin/ld: resource/softfloat/build/softfloat.a(f16_sqrt.o): relocation R_X86_64_PC32 against symbol `softfloat_approxRecipSqrt_1k0s' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

So, change `make clean` to `make clean-all` to cleanup all outputs that may be in-compatible between builds.