### PR TITLE
docs(xsenv): modify the file extension and path of XSTop

### DIFF
--- a/docs/tools/xsenv-en.md
+++ b/docs/tools/xsenv-en.md
@@ -91,11 +91,11 @@ This command will clone some necessary submodules.
 
 ### Generate single core Verilog code
 
-Run `make verilog` under `/xs-env/XiangShan`, this command will compile Xiangshan's Chisel code and generate Verilog, the output Verilog file is `XiangShan/build/XSTop.v`. It takes about 40 minutes.
+Run `make verilog` under `/xs-env/XiangShan`, this command will compile Xiangshan's Chisel code and generate Verilog, the output Verilog file is `XiangShan/build/rtl/XSTop.sv`. It takes about 40 minutes.
 
 ### Generate dual core Verilog code
 
-Run `make verilog NUM_CORES=2` under `/xs-env/XiangShan`, this command will generate the Verilog of Xiangshan (dual core), the output Verilog file is `XiangShan/build/XSTop.v`
+Run `make verilog NUM_CORES=2` under `/xs-env/XiangShan`, this command will generate the Verilog of Xiangshan (dual core), the output Verilog file is `XiangShan/build/rtl/XSTop.sv`
 
 > Tip: Generate Verilog is slow. It is recommended to use tools such as Tmux to run these commands in background. You can add `CONFIG=MinimalConfig` to command-line arguments which will generate Verilog code of Xiangshan with minimal configuration.
 

--- a/docs/tools/xsenv.md
+++ b/docs/tools/xsenv.md
@@ -97,7 +97,7 @@ make init
 
 ### 生成可综合的单核代码
 
-在 `/xs-env/XiangShan` 下运行 `make verilog` ，该命令将会编译香山的 Chisel 代码，生成 Verilog，输出的文件在 `XiangShan/build/XSTop.v`
+在 `/xs-env/XiangShan` 下运行 `make verilog` ，该命令将会编译香山的 Chisel 代码，生成 Verilog，输出的文件在 `XiangShan/build/rtl/XSTop.sv`
 
 > 提示： `make verilog`命令生成的Verilog文件用于生成FPGA的bitstream和流片，去除了Difftest等仿真用的调试模块。
 如果需要生成带有Difftest的用于仿真的Verilog文件，可以使用`make sim-verilog`命令。
@@ -108,7 +108,7 @@ make init
 ### 生成可综合的双核代码
 
 
-在 `/xs-env/XiangShan` 下运行 `make verilog NUM_CORES=2` ，该命令将会生成香山双核的 Verilog，输出的文件在 `XiangShan/build/XSTop.v`
+在 `/xs-env/XiangShan` 下运行 `make verilog NUM_CORES=2` ，该命令将会生成香山双核的 Verilog，输出的文件在 `XiangShan/build/rtl/XSTop.sv`
 
 
 > 提示：生成完整香山核的 Verilog 代码所需的时间会稍久，推荐大家使用 Tmux 等工具在后台运行上述命令。可以在命令行参数中添加 `CONFIG=MinimalConfig`，将会生成一个最小配置的香山的 Verilog 代码。（参见：[香山参数系统说明](https://xiangshan-doc.readthedocs.io/zh_CN/latest/misc/config/)）


### PR DESCRIPTION
In current version of `XiangShan`, the output Verilog file of `XSTop` should be `XiangShan/build/rtl/XSTop.sv`.