### PR TITLE
chore: add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/** -linguist-documentation
+*.md linguist-detectable


### PR DESCRIPTION
This patch makes github-linguist work properly. Previously, docs folder and *.md files are ignored by github-linguist.