### PR TITLE
misc: add more gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 
+build/
+site/
+venv
+.venv


### PR DESCRIPTION
build and site are for mkdocs; venv and .venv are for python virtual environment