### PR TITLE
mkdocs: Add color scheme toggle options for light and dark modes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,22 @@ theme:
   language: zh
   features:
     - navigation.tabs
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: 跟随系统
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-sunny
+        name: 浅色模式
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-night
+        name: 深色模式
+
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
Add color scheme toggle options for light and dark modes.
Referenced the official document [guide](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/?h=dark+mode#automatic-light-dark-mode).